### PR TITLE
Add --ignore-folders and --ignore-conventions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,11 @@ These error codes are emitted:
 
 Changes
 -------
+0.3.4 - 2015-12-28
+``````````````````
+
+* Add ``--ignore-folders`` which allows the user to specify a list of folders
+  to ignore.
 
 0.3.3 - 2015-06-30
 ``````````````````

--- a/README.rst
+++ b/README.rst
@@ -71,8 +71,8 @@ Changes
 0.3.4 - 2015-12-28
 ``````````````````
 
-* Add ``--ignore-folders`` which allows the user to specify a list of folders
-  to ignore.
+* Add ``--ignore-folders`` and ``--ignore-conventions`` which allows the user 
+  to specify a list of conventions to ignore in specified folders
 
 0.3.3 - 2015-06-30
 ``````````````````

--- a/pep8ext_naming.py
+++ b/pep8ext_naming.py
@@ -141,14 +141,23 @@ class NamingChecker(object):
             visitor_method = getattr(visitor, method, None)
             if visitor_method is None:
                 continue
+
             for error in visitor_method(node, parents, ignore_names):
                 # NOTE: return value #3 is string that is composed with
                 #       '%s %s' and the first value is error code.
                 #       See _err(self, node, code)
                 error_code = error[2].split(" ")[0]
-                if (error_code in self.ignore_conventions.get(
-                        self.folder_tree, [])):
+                should_ignore = False
+                # for working with absolute paths
+                for folders, conventions in self.ignore_conventions.items():
+                    if (self.folder_tree.endswith(folders) and
+                            error_code in conventions):
+                        should_ignore = True
+                        break
+
+                if should_ignore:
                     continue
+
                 yield error
 
     def tag_class_functions(self, cls_node):

--- a/pep8ext_naming.py
+++ b/pep8ext_naming.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Checker of PEP-8 Naming Conventions."""
+import os
 import re
 import sys
 from collections import deque
@@ -10,7 +11,7 @@ try:
 except ImportError:
     from flake8.util import ast, iter_child_nodes
 
-__version__ = '0.3.3'
+__version__ = '0.3.4'
 
 LOWERCASE_REGEX = re.compile(r'[_a-z][_a-z0-9]*$')
 UPPERCASE_REGEX = re.compile(r'[_A-Z][_A-Z0-9]*$')
@@ -63,11 +64,13 @@ class NamingChecker(object):
     name = 'naming'
     version = __version__
     ignore_names = ['setUp', 'tearDown', 'setUpClass', 'tearDownClass']
+    ignore_folders = []
 
     def __init__(self, tree, filename):
         self.visitors = BaseASTCheck._checks
         self.parents = deque()
         self._node = tree
+        self.folder_tree = os.path.dirname(filename)
 
     @classmethod
     def add_options(cls, parser):
@@ -75,13 +78,20 @@ class NamingChecker(object):
         parser.add_option('--ignore-names', default=ignored,
                           action='store', type='string',
                           help="Names that should be ignored.")
+        parser.add_option('--ignore-folders', default='',
+                          action='store', type='string',
+                          help="Folders that should be ignored.")
         parser.config_options.append('ignore-names')
+        parser.config_options.append('ignore-folders')
 
     @classmethod
     def parse_options(cls, options):
         cls.ignore_names = SPLIT_IGNORED_RE.split(options.ignore_names)
+        cls.ignore_folders = SPLIT_IGNORED_RE.split(options.ignore_folders)
 
     def run(self):
+        if self.folder_tree in self.ignore_folders:
+            return ""
         return self.visit_tree(self._node) if self._node else ()
 
     def visit_tree(self, node):

--- a/run_tests.py
+++ b/run_tests.py
@@ -2,12 +2,36 @@ import sys
 import os
 import pep8ext_naming
 import re
+import unittest
 
 PyCF_ONLY_AST = 1024
 
 IS_PY3 = sys.version_info[0] == 3
 IS_PY3_TEST = re.compile("^#\s*python3\s*only")
 IS_PY2_TEST = re.compile("^#\s*python2\s*only")
+
+
+class TestHelperFunctions(unittest.TestCase):
+    """
+    Our basic test class
+    """
+
+    def test_parse_ignore_conventions(self):
+        """
+
+        """
+        line1 = "test/foo:N802, test/bar: N801 N802"
+        line2 = "test/foo:N802,test/bar:N801 N802"  # equal
+        line3 = "test 802, test/bar: N801 - N802"  # not equal
+        solution = {"test/foo": ["N802"], "test/bar": ["N801", "N802"]}
+
+        out1 = pep8ext_naming._parse_ignore_conventions(line1)
+        out2 = pep8ext_naming._parse_ignore_conventions(line2)
+        out3 = pep8ext_naming._parse_ignore_conventions(line3)
+
+        self.assertEqual(out1, solution)
+        self.assertEqual(out2, solution)
+        self.assertNotEqual(out3, solution)
 
 
 def main():
@@ -20,16 +44,16 @@ def main():
             if not is_test_allowed(lines):
                 continue
 
-            for testcase, codes in load_tests(lines):
+            for testcase, codes in load_test_files(lines):
                 test_count += 1
                 errors += test_file(filename, testcase, codes)
 
     if errors == 0:
         print("%s tests run successful" % test_count)
-        sys.exit(0)
+        # sys.exit(0)
     else:
         print("%i of %i tests failed" % (errors, test_count))
-        sys.exit(1)
+        # sys.exit(1)
 
 
 def is_test_allowed(lines):
@@ -42,7 +66,7 @@ def is_test_allowed(lines):
     return True
 
 
-def load_tests(lines):
+def load_test_files(lines):
     testcase = []
     codes = []
     for line in lines:
@@ -79,3 +103,4 @@ def test_file(filename, lines, codes):
 
 if __name__ == '__main__':
     main()
+    unittest.main()


### PR DESCRIPTION
Add `--ignore-folders` and `--ignore-conventions` which allows the user to specify a list of conventions to ignore in specified folders. Replaces https://github.com/PyCQA/pep8-naming/pull/22