### PR TITLE
Fix failing builds on Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   matrix:
   - TOXENV=py26
   - TOXENV=py27
-  - TOXENV=py32
   - TOXENV=py33
   - TOXENV=py34
   - TOXENV=pypy

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,pypy,pypy3
+envlist = py26,py27,py33,py34,pypy,pypy3
 
 [testenv]
 commands = python run_tests.py


### PR DESCRIPTION
Builds of https://github.com/PyCQA/pep8-naming/pull/24 and https://github.com/PyCQA/pep8-naming/pull/22 are failing because virtualenv dropped support for python 3.2.

As noted [here](https://github.com/pypa/pip/issues/3796), only 0.07% of pip traffic is initiated by users of Python 3.2, so I think it's entirely viable to drop support for Python 3.2. 

Alternatively, `.travis.yml` can be changed by pinning the version of virtualenv (https://github.com/travis-ci/travis-ci/issues/5485):
```
    -  - pip install travis
    +  - pip install travis "virtualenv<14.0.0"
```

