### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ script: tox
 
 matrix:
   include:
-    - env: TOXENV=py26
-      python: 2.6
     - env: TOXENV=py27
       python: 2.7
     - env: TOXENV=py33

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,pypy,pypy3
+envlist = py27,py33,py34,py35,pypy,pypy3
 
 [testenv]
 commands = python run_tests.py


### PR DESCRIPTION
Yesterday marks 3 years since the last release of Python 2.6! 🎉

To celebrate, I'm attempting to drop support for it from 156 prominent Python packages (one for every week it's past end-of-life)--including this one!
