### PR TITLE
Include license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include LICENSE
 include run_tests.py
 recursive-include testsuite *.py


### PR DESCRIPTION
Add license file to `MANIFEST.in` to ensure it is included in packages.