### PR TITLE
Add configurable list of classmethod / staticmethod decorators

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     url='https://github.com/flintwork/pep8-naming',
     license='Expat license',
     py_modules=['pep8ext_naming'],
+    install_requires=['flake8_polyfill>=1.0.2,<2'],
     zip_safe=False,
     entry_points={
         'flake8.extension': [

--- a/testsuite/N804.py
+++ b/testsuite/N804.py
@@ -14,3 +14,8 @@ class Foo(object):
 
     def __init_subclass(self, ads):
         pass
+#: N804(--classmethod-decorators=clazzy,cool)
+class NewClassIsRequired(object):
+    @cool
+    def test(self, sy):
+        pass

--- a/testsuite/N805.py
+++ b/testsuite/N805.py
@@ -15,7 +15,72 @@ class Foo(object):
     def __prepare__(cls):
         pass
 
+    @staticmethod
+    def test(so, exciting):
+        pass
+
+    def test1(cls):
+        pass
+    test1 = classmethod(test1)
+
+    def test2(so, exciting):
+        pass
+    test2 = staticmethod(test2)
 #: Okay
 class Foo(object):
     def __init_subclass__(cls):
         pass
+#: Okay(--classmethod-decorators=clazzy,cool)
+class NewClassmethodDecorators(object):
+    @clazzy
+    def test1(cls, sy):
+        pass
+
+    @cool
+    def test2(cls, sy):
+        pass
+
+    def test3(cls, sy):
+        pass
+    test3 = clazzy(test3)
+
+    def test4(cls, sy):
+        pass
+    test4 = cool(test4)
+#: N805(--classmethod-decorators=clazzy,cool)
+class ButWeLostTheOriginalClassMethodDecorator(object):
+    @classmethod
+    def test(cls, sy):
+        pass
+#: N805(--classmethod-decorators=clazzy,cool)
+class ButWeLostTheOriginalClassMethodLateDecorator(object):
+    def test(cls, sy):
+        pass
+    test = classmethod(test)
+#: Okay(--staticmethod-decorators=ecstatik,stcmthd)
+class NewStaticMethodDecorators(object):
+    @ecstatik
+    def test1(so, exciting):
+        pass
+
+    @stcmthd
+    def test2(so, exciting):
+        pass
+
+    def test3(so, exciting):
+        pass
+    test3 = ecstatik(test3)
+
+    def test4(so, exciting):
+        pass
+    test4 = stcmthd(test4)
+#: N805(--staticmethod-decorators=exstatik,stcmthd)
+class ButWeLostTheOriginalStaticMethodDecorator(object):
+    @staticmethod
+    def test(so, exciting):
+        pass
+#: N805(--staticmethod-decorators=exstatik,stcmthd)
+class ButWeLostTheOriginalStaticMethodLateDecorator(object):
+    def test(so, exciting):
+        pass
+    test = staticmethod(test)


### PR DESCRIPTION
- Add classmethod-decorator and staticmethod-decorator config parameters
- Add support for parsing CLI-style flake8-config parameters in testing
  framework.
- Remove support for multiple `codes` in a testcase, since it was never used.
- Add tests for late-decorated methods

Fixes #38