### PR TITLE
Correct N804/N805 for __init_subclass__

### DIFF
--- a/pep8ext_naming.py
+++ b/pep8ext_naming.py
@@ -154,7 +154,7 @@ class NamingChecker(object):
                 continue
 
             node.function_type = 'method'
-            if node.name == '__new__':
+            if node.name in ('__new__', '__init_subclass__'):
                 node.function_type = 'classmethod'
 
             if node.name in late_decoration:

--- a/testsuite/N804.py
+++ b/testsuite/N804.py
@@ -11,3 +11,6 @@ class Foo(object):
     @calling()
     def test(self, ads):
         pass
+
+    def __init_subclass(self, ads):
+        pass

--- a/testsuite/N805.py
+++ b/testsuite/N805.py
@@ -14,3 +14,8 @@ class Foo(object):
     @classmethod
     def __prepare__(cls):
         pass
+
+#: Okay
+class Foo(object):
+    def __init_subclass__(cls):
+        pass


### PR DESCRIPTION
According to pep 0487, the `__init_subclass__` method is implicitly
considered a classmethod. Thus it should be considered as an exception
of N804/N805 (first argument should be named self/cls). This is already
implemented for `__new__` so extend using the same logic.