### PR TITLE
id attribute not always available

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -182,7 +182,7 @@ class NamingChecker(object):
 
         # If this class inherits from `type`, it's a metaclass, and we'll
         # consider all of it's methods to be classmethods.
-        ismetaclass = any(name for name in cls_node.bases if name.id == 'type')
+        ismetaclass = any(name for name in cls_node.bases if getattr(name, 'id', None) == 'type')
 
         # iterate over all functions and tag them
         for node in iter_child_nodes(cls_node):


### PR DESCRIPTION
Fixes #53.

I don't think "rage-replacing" `xxx.id` with `getattr(xxx, "id", None)` can be done / makes sense.  Sometimes `xxx.id` is used as a key in a dictionary, etc.  I only fixed the line that caused crashes for me.

Logically it should be equivalent though, and installing this locally `pep8-naming` no longer crashes :)