### PR TITLE
fix ignore bug in class names

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -225,6 +225,8 @@ class ClassNameCheck(BaseASTCheck):
     N801 = "class name '{name}' should use CapWords convention"
 
     def visit_classdef(self, node, parents, ignore=None):
+        if ignore and node.name in ignore:
+            return
         if not self.check(node.name):
             yield self.err(node, 'N801', node.name)
 


### PR DESCRIPTION
This fixes a bug where ignoring names won't work with class names.
Unfortunately I can't add a test, because options will carry over to the next test, breaking other tests.
Is it possible to release this fix soon?