### PR TITLE
Add .idea and .pytest_cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ dist
 .pydevproject
 .settings/
 build/
-
+.idea
+.pytest_cache


### PR DESCRIPTION
.idea is a folder used in PyCharm IDE. Some other PyCQA projects like
pylink and pydocstyle also have it ignored.