### PR TITLE
Detect N806 errors within with_item

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -349,7 +349,7 @@ class VariablesInFunctionCheck(BaseASTCheck):
     check = LOWERCASE_REGEX.match
     N806 = "variable '{name}' in function should be lowercase"
 
-    def visit_assign(self, node, parents, ignore=None):
+    def _find_errors(self, assignment_target, parents):
         for parent_func in reversed(parents):
             if isinstance(parent_func, ast.ClassDef):
                 return
@@ -357,6 +357,14 @@ class VariablesInFunctionCheck(BaseASTCheck):
                 break
         else:
             return
+        for name in _extract_names(assignment_target):
+            if name in parent_func.global_names:
+                continue
+            if self.check(name) or name[:1] == '_':
+                continue
+            yield self.err(assignment_target, 'N806', name)
+
+    def visit_assign(self, node, parents, ignore=None):
         if isinstance(node.value, ast.Call):
             if isinstance(node.value.func, ast.Attribute):
                 if node.value.func.attr == 'namedtuple':
@@ -365,16 +373,17 @@ class VariablesInFunctionCheck(BaseASTCheck):
                 if node.value.func.id == 'namedtuple':
                     return
         for target in node.targets:
-            for name in _extract_names(target):
-                if name in parent_func.global_names:
-                    continue
-                if self.check(name) or name[:1] == '_':
-                    continue
-                yield self.err(target, 'N806', name)
+            for error in self._find_errors(target, parents):
+                yield error
+
+    def visit_with(self, node, parents, ignore):
+        for item in node.items:
+            for error in self._find_errors(item.optional_vars, parents):
+                yield error
 
 
 def _extract_names(assignment_target):
-    """Return assignment_target target ids."""
+    """Yield assignment_target ids."""
     target_type = type(assignment_target)
     if target_type is ast.Name:
         yield assignment_target.id

--- a/testsuite/N806.py
+++ b/testsuite/N806.py
@@ -67,3 +67,36 @@ def recursive_unpack():
 #: Okay
 def assingnment_to_attribute():
     a.b = 1
+#: N806
+def f():
+    with Foo(), Bar() as Bad:
+        pass
+#: Okay
+def f():
+    with FOO() as foo, bar() as bar:
+        pass
+#: Okay
+def f():
+    with suppress(E):
+        pass
+    with contextlib.suppress(E):
+        pass
+#: Okay
+with Test() as bar:
+    pass
+#: N806
+def f():
+    with Test() as BAD:
+        pass
+#: Okay
+def f():
+    with C() as [a, b, c]:
+        pass
+#: N806
+def f():
+    with C() as [a, Bad, c]:
+        pass
+#: N806
+def f():
+    with C() as (a, b, baD):
+        pass


### PR DESCRIPTION
Thsi will partially resove issue #34, i.e. it only works for
variables within functions/methods, not global variables.
I have an idea for creating a new error code for global scope
variables, but to avoid complicating this patch I'm leaving
that for another one.