### PR TITLE
Fix casing detection for non-ascii characters

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,3 +1,4 @@
+import io
 import optparse
 import os
 import re
@@ -20,7 +21,8 @@ def main():
     test_count = 0
     errors = 0
     for filename in os.listdir('testsuite'):
-        with open(os.path.join('testsuite', filename)) as fd:
+        filepath = os.path.join('testsuite', filename)
+        with io.open(filepath, encoding='utf8') as fd:
             lines = list(fd)
             if not is_test_allowed(lines):
                 continue

--- a/testsuite/N801_py3.py
+++ b/testsuite/N801_py3.py
@@ -1,0 +1,19 @@
+# python3 only
+#: Okay
+class Γ:
+    pass
+#: Okay
+class ΓγΓγ:
+    pass
+#: Okay
+class ΓγΓ6:
+    pass
+#: Okay
+class _Γ:
+    pass
+#: N801
+class γ:
+    pass
+#: N801
+class _γ:
+    pass

--- a/testsuite/N802_py3.py
+++ b/testsuite/N802_py3.py
@@ -1,0 +1,7 @@
+# python3 only
+#: Okay
+def γ(x):
+    pass
+#: Okay
+def γ6(x):
+    pass

--- a/testsuite/N803_py3.py
+++ b/testsuite/N803_py3.py
@@ -11,3 +11,21 @@ def compare(a, b, *VERY, bad=None):
 #: N803
 def compare(a, b, *ok, fine=None, **BAD):
     pass
+#: Okay
+def foo(α, ß, γ):
+    pass
+#: Okay
+def foo(α, ß=''):
+    pass
+#: Okay
+def foo(**κ):
+    pass
+#: Okay
+def foo(*α):
+    pass
+#: Okay
+def foo(**κ2):
+    pass
+#: Okay
+def foo(*α2):
+    pass

--- a/testsuite/N806_py3.py
+++ b/testsuite/N806_py3.py
@@ -2,6 +2,8 @@
 #: Okay
 VAR1, *VAR2, VAR3 = 1, 2, 3
 #: Okay
+Α, *Β, Γ = 1, 2, 3
+#: Okay
 [VAR1, *VAR2, VAR3] = (1, 2, 3)
 #: N806
 def extended_unpacking_not_ok():
@@ -15,3 +17,20 @@ def assing_to_unpack_ok():
 #: N806
 def assing_to_unpack_not_ok():
     a, *[bB] = 1, 2
+#: Okay
+Γ = 1
+#: N806
+def f():
+    Δ = 1
+#: N806
+def f():
+    _Δ = 1
+#: Okay
+def f():
+    γ = 1
+#: Okay
+def f():
+    _γ = 1
+#: Okay
+def f():
+    h, _, γ = s.partition('sep')

--- a/testsuite/N807_py3.py
+++ b/testsuite/N807_py3.py
@@ -1,0 +1,15 @@
+# python3 only
+#: Okay
+class C:
+    def γ(self):
+        pass
+#: N807
+def __β(self):
+    pass
+#: N807
+def __β6(self):
+    pass
+#: Okay
+class C:
+    def γ1(self):
+        pass

--- a/testsuite/N81x_py3.py
+++ b/testsuite/N81x_py3.py
@@ -1,0 +1,11 @@
+# python3 only
+#: Okay
+import good as γ
+#: Okay
+from mod import good as γ
+#: Okay
+import GOOD as Γ
+#: Okay
+from mod import GOOD as Γ
+#: Okay
+from mod import GOOD as Γ1


### PR DESCRIPTION
Note: Non-ASCII identifiers are a py3-only feature (PEP 3131).
run_tests.py:
    Open files using io.open and utf8 encoding. (python2's built-in open
    does not have the encoding parameter.)
pep8ext_naming.py:
    Remove global case-checking regexes. Use the equivalent str methods
    which also handle non-ascii characters properly.
testsuite/:
    Add tests for non-ascii identifiers.
Fix issue #37.