### PR TITLE
Fix a bug in ClassNameCheck

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -234,7 +234,7 @@ class ClassNameCheck(BaseASTCheck):
         name = node.name
         if ignore and name in ignore:
             return
-        if not name.lstrip('_')[0].isupper():
+        if not name.lstrip('_')[:1].isupper():
             yield self.err(node, 'N801', name=name)
 
 

--- a/testsuite/N801.py
+++ b/testsuite/N801.py
@@ -9,3 +9,6 @@ class Good(object):
 #: Okay
 class VeryGood(object):
     pass
+#: N801
+class _:
+    pass


### PR DESCRIPTION
name.lstrip('_')[0] may raise an IndexError if the name is `_`.
Thanks to @jparise for seeing this bug.