### PR TITLE
N802: Ignore Django setUpTestData method in

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -90,7 +90,7 @@ class NamingChecker(object):
     """Checker of PEP-8 Naming Conventions."""
     name = 'naming'
     version = __version__
-    ignore_names = ['setUp', 'tearDown', 'setUpClass', 'tearDownClass']
+    ignore_names = ['setUp', 'tearDown', 'setUpClass', 'tearDownClass', 'setUpTestData']
     decorator_to_type = _build_decorator_to_type(
         _default_classmethod_decorators, _default_staticmethod_decorators)
 

--- a/testsuite/N802.py
+++ b/testsuite/N802.py
@@ -56,3 +56,5 @@ class TestCase:
         pass
     def tearDownClass(self):
         pass
+    def setUpTestData(self):
+        pass


### PR DESCRIPTION
Django [provides](https://docs.djangoproject.com/en/2.0/topics/testing/tools/#django.test.TestCase.setUpTestData) a method called `setUpTestData` in its unittest extension class.

Here goes the fix to allow projects using django and `setUpTestData` use this awesome library.