### PR TITLE
Support module __getattr__ and __dir__ functions

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -261,6 +261,8 @@ class FunctionNameCheck(BaseASTCheck):
         name = node.name
         if ignore and name in ignore:
             return
+        if name in ('__dir__', '__getattr__'):
+            return
         if not name.islower() and name != '_':
             yield self.err(node, 'N802', name=name)
         if function_type == 'function' and '__' in (name[:2], name[-2:]):

--- a/testsuite/N807.py
+++ b/testsuite/N807.py
@@ -35,3 +35,9 @@ class ClassName(object):
     def method(self):
         def __bad():
             pass
+#: Okay
+def __dir__():
+    pass
+#: Okay
+def __getattr__(name):
+    pass


### PR DESCRIPTION
PEP-562 adds support for module-level `__getattr__` and `__dir__`
functions. Don't flag them as N807 function name violations.