### PR TITLE
Catch N81x errors in `import x as y` statements

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -352,6 +352,8 @@ class ImportAsCheck(BaseASTCheck):
             elif asname.isupper():
                 yield self.err(node, 'N814', **err_kwargs)
 
+    visit_import = visit_importfrom
+
 
 class VariablesCheck(BaseASTCheck):
     """

--- a/testsuite/N81x.py
+++ b/testsuite/N81x.py
@@ -1,3 +1,7 @@
+#: N812:1:1
+import os as OS
+#: Okay
+import os as myos
 #: Okay
 import good as good
 #: Okay


### PR DESCRIPTION
Fixes #84.