### PR TITLE
Allow lowercase names to be imported as _

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     from flake8.util import ast, iter_child_nodes
 
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 
 PYTHON_VERSION = sys.version_info[:3]
 PY2 = PYTHON_VERSION[0] == 2
@@ -346,7 +346,7 @@ class ImportAsCheck(BaseASTCheck):
                 if not asname.isupper():
                     yield self.err(node, 'N811', **err_kwargs)
             elif original_name.islower():
-                if not asname.islower():
+                if not asname.islower() and asname != '_':
                     yield self.err(node, 'N812', **err_kwargs)
             elif asname.islower():
                 yield self.err(node, 'N813', **err_kwargs)

--- a/testsuite/N81x.py
+++ b/testsuite/N81x.py
@@ -5,6 +5,8 @@ import os as myos
 #: Okay
 import good as good
 #: Okay
+import underscore as _
+#: Okay
 from mod import good as nice, NICE as GOOD, Camel as Memel
 #: N811:1:1
 from mod import GOOD as bad


### PR DESCRIPTION
This supports the common case of importing common utility routines (such
as Django's gettext functions) as `_` for convenience.

Fixes #92