### PR TITLE
Honor ignore-names in the variable names checks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,9 +72,9 @@ The following flake8 options are added:
 
 --ignore-names              Ignore errors for specific variable names.
 
-                            Currently, this option can only be used for N802 errors (`#43 <https://github.com/PyCQA/pep8-naming/issues/43>`_).
+                            Currently, this option can only be used for N802, N806, N815, and N816 errors.
 
-                            Default: ``setUp,tearDown,setUpClass,tearDownClass,setUpTestData``.
+                            Default: ``setUp,tearDown,setUpClass,tearDownClass,setUpTestData,failureException,longMessage,maxDiff``.
 
 --classmethod-decorators    List of method decorators pep8-naming plugin should consider class method.
 

--- a/testsuite/N815.py
+++ b/testsuite/N815.py
@@ -10,6 +10,9 @@ class C:
 #: Okay
 class C:
     _1 = 0
+#: Okay
+class C:
+    maxDiff = None
 #: N815:2:5
 class C:
     mixedCase = 0


### PR DESCRIPTION
`ignore-names` was previously only checked for N802 errors. This change
extends the code to also consider `ignore-names` for the N806, N815, and
N816 checks.

The default set of names has been extended to include some camelCase
names from the `unittest` package that may appear in user code:

 - failureException
 - longMessage
 - maxDiff

Fixes #93