### PR TITLE
Allow function arguments to be named _

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -279,7 +279,7 @@ class FunctionNameCheck(BaseASTCheck):
             return
         if name in ('__dir__', '__getattr__'):
             return
-        if not name.islower() and name != '_':
+        if name.lower() != name:
             yield self.err(node, 'N802', name=name)
         if function_type == 'function' and '__' in (name[:2], name[-2:]):
             yield self.err(node, 'N807', name=name)
@@ -308,7 +308,7 @@ class FunctionArgNamesCheck(BaseASTCheck):
                 return node, arg
 
         for arg, name in arg_name(node.args.vararg), arg_name(node.args.kwarg):
-            if name is not None and not name.islower() and name != '_':
+            if name is not None and name.lower() != name:
                 yield self.err(arg, 'N803', name=name)
                 return
 
@@ -325,7 +325,7 @@ class FunctionArgNamesCheck(BaseASTCheck):
             if name0 != 'cls':
                 yield self.err(arg0, 'N804')
         for arg, name in arg_name_tuples:
-            if not name.islower() and name != '_':
+            if name.lower() != name:
                 yield self.err(arg, 'N803', name=name)
                 return
 
@@ -352,7 +352,7 @@ class ImportAsCheck(BaseASTCheck):
                 if not asname.isupper():
                     yield self.err(node, 'N811', **err_kwargs)
             elif original_name.islower():
-                if not asname.islower() and asname != '_':
+                if asname.lower() != asname:
                     yield self.err(node, 'N812', **err_kwargs)
             elif asname.islower():
                 yield self.err(node, 'N813', **err_kwargs)
@@ -444,7 +444,7 @@ class VariablesCheck(BaseASTCheck):
     def function_variable_check(func, var_name):
         if var_name in func.global_names:
             return None
-        if var_name.islower() or var_name == '_':
+        if var_name.lower() == var_name:
             return None
         return 'N806'
 

--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -308,10 +308,9 @@ class FunctionArgNamesCheck(BaseASTCheck):
                 return node, arg
 
         for arg, name in arg_name(node.args.vararg), arg_name(node.args.kwarg):
-            if name is not None:
-                if not name.islower():
-                    yield self.err(arg, 'N803', name=name)
-                    return
+            if name is not None and not name.islower() and name != '_':
+                yield self.err(arg, 'N803', name=name)
+                return
 
         arg_name_tuples = get_arg_name_tuples(node)
         if not arg_name_tuples:
@@ -326,7 +325,7 @@ class FunctionArgNamesCheck(BaseASTCheck):
             if name0 != 'cls':
                 yield self.err(arg0, 'N804')
         for arg, name in arg_name_tuples:
-            if not name.islower():
+            if not name.islower() and name != '_':
                 yield self.err(arg, 'N803', name=name)
                 return
 

--- a/testsuite/N803.py
+++ b/testsuite/N803.py
@@ -40,6 +40,21 @@ def b13(BAD, *VERYBAD, **EXTRABAD):
 #: N803:1:9
 def b14(BAD):
     pass
+#: Okay
+def b15(_):
+    pass
+#: Okay
+def b16(_a):
+    pass
+#: Okay
+def b17(a, _):
+    pass
+#: Okay
+def b18(a, *_):
+    pass
+#: Okay
+def b19(a, **_):
+    pass
 #: N803:2:24
 class Test(object):
     def __init__(self, BAD):


### PR DESCRIPTION
It's common for some arguments to be named `_`, often to indicate that
they're unused. Previously, our "is lowercase" check would fail on these
cases.

Fixes #95