### PR TITLE
Allow uppercase abbreviations of CamelCase names

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -358,7 +358,10 @@ class ImportAsCheck(BaseASTCheck):
             elif asname.islower():
                 yield self.err(node, 'N813', **err_kwargs)
             elif asname.isupper():
-                yield self.err(node, 'N814', **err_kwargs)
+                # Special case: Allow uppercase abbreviations of CamelCased
+                # names, like ElementTree and BeautifulSoup use.
+                if asname != ''.join(filter(str.isupper, original_name)):
+                    yield self.err(node, 'N814', **err_kwargs)
 
     visit_import = visit_importfrom
 

--- a/testsuite/N81x.py
+++ b/testsuite/N81x.py
@@ -16,3 +16,5 @@ from mod import good as Bad
 from mod import CamelCase as noncamle
 #: N814:1:1
 from mod import CamelCase as CONSTANT
+#: Okay
+from mod import CamelCase as CC


### PR DESCRIPTION
This avoids flagging code such as the following as errors:

```py
import xml.etree.ElementTree as ET
from BeautifulSoup import BeautifulSoup as BS
```

See #52 for discussions as to whether or not this is actually a good idea.