### PR TITLE
Add py36 and py37 environments to tox.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,7 @@ matrix:
       python: pypy
     - env: TOXENV=py27-flake8
       python: 2.7
-    - env: TOXENV=py34-flake8
-      python: 3.4
+    - env: TOXENV=py37-flake8
+      dist: xenial
+      sudo: required
+      python: 3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy,pypy3
+envlist = py27,py33,py34,py35,py36,py37,pypy,pypy3
 
 [testenv]
 commands = python run_tests.py
@@ -9,8 +9,8 @@ deps =
     flake8
 commands = flake8 {posargs} pep8ext_naming.py
 
-[testenv:py34-flake8]
-basepython = python3.4
+[testenv:py37-flake8]
+basepython = python3.7
 deps =
     flake8
 commands = flake8 {posargs} pep8ext_naming.py


### PR DESCRIPTION
Also move the Python 3 flake8 test environment to Python 3.7 so that it
tests against the latest language grammar (including async/await, for
example).