### PR TITLE
Relax N807 to "start *and* end with '__'"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ These error codes are emitted:
 +------+-------------------------------------------------------+
 | N806 | variable in function should be lowercase              |
 +------+-------------------------------------------------------+
-| N807 | function name should not start or end with '__'       |
+| N807 | function name should not start and end with '__'      |
 +------+-------------------------------------------------------+
 +------+-------------------------------------------------------+
 | N811 | constant imported as non constant                     |

--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -271,7 +271,7 @@ class FunctionNameCheck(BaseASTCheck):
     prevailing style (e.g. threading.py), to retain backwards compatibility.
     """
     N802 = "function name '{name}' should be lowercase"
-    N807 = "function name '{name}' should not start or end with '__'"
+    N807 = "function name '{name}' should not start and end with '__'"
 
     def visit_functiondef(self, node, parents, ignore=None):
         function_type = getattr(node, 'function_type', _FunctionType.FUNCTION)
@@ -283,7 +283,7 @@ class FunctionNameCheck(BaseASTCheck):
         if name.lower() != name:
             yield self.err(node, 'N802', name=name)
         if (function_type == _FunctionType.FUNCTION
-                and '__' in (name[:2], name[-2:])):
+                and name[:2] == '__' and name[-2:] == '__'):
             yield self.err(node, 'N807', name=name)
 
     visit_asyncfunctiondef = visit_functiondef

--- a/testsuite/N807.py
+++ b/testsuite/N807.py
@@ -21,19 +21,30 @@ class C3:
                 break
     except:
         pass
-#: N807
+#: Okay
+def _bad():
+    pass
+#: Okay
 def __bad():
     pass
-#: N807:1:5
+#: Okay
+def bad_():
+    pass
+#: Okay
 def bad__():
     pass
 #: N807
 def __bad__():
     pass
-#: N807
+#: Okay
 class ClassName(object):
     def method(self):
         def __bad():
+            pass
+#: N807
+class ClassName(object):
+    def method(self):
+        def __bad__():
             pass
 #: Okay(--ignore-names=__bad)
 def __bad():

--- a/testsuite/N807_py3.py
+++ b/testsuite/N807_py3.py
@@ -3,11 +3,17 @@
 class C:
     def γ(self):
         pass
-#: N807
+#: Okay
 def __β(self):
     pass
+#: Okay
+def β__(self):
+    pass
 #: N807
-def __β6(self):
+def __β__(self):
+    pass
+#: N807
+def __β6__(self):
     pass
 #: Okay
 class C:

--- a/testsuite/N807_py35.py
+++ b/testsuite/N807_py35.py
@@ -3,6 +3,12 @@
 class C:
     async def γ(self):
         pass
-#: N807
+#: Okay
 async def __β(self):
+    pass
+#: Okay
+async def β__(self):
+    pass
+#: N807
+async def __β__(self):
     pass


### PR DESCRIPTION
N807 previously flagged function names that started *or* ended up `__`.
Instead, relax this restriction and only flag function names that both
start *and* end with `__`.

This brings is closer to the spirit of PEP8, which states "Never invent
such names; only use them as documented." when referring to "magic"
names like `__author__`, `__import__`, `__file__`, etc., while allowing
people to prefix or suffix their functions with `__` if they like.

Fixes #51