### PR TITLE
remove frozenset

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -150,7 +150,7 @@ class NamingChecker(object):
 
     @classmethod
     def parse_options(cls, options):
-        cls.ignore_names = frozenset(options.ignore_names)
+        cls.ignore_names = options.ignore_names
         cls.decorator_to_type = _build_decorator_to_type(
             options.classmethod_decorators,
             options.staticmethod_decorators)


### PR DESCRIPTION
This fixes a regression introduced in #96. See https://travis-ci.org/colcon/colcon-core/jobs/488633329 for an example of the resulting exception in [flake8/utils.py:44](https://github.com/PyCQA/flake8/blob/e7b8493b5d7af36f6c348566a7c3316b30e5b5ee/src/flake8/utils.py#L44):

> TypeError: expected string or bytes-like object

It would be great if the fix could be shipped in a patch release soon.