### PR TITLE
Fix ignore-names option initialization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+0.8.2 - 2019-02-04
+------------------
+
+* Fix a problem with ``ignore-names`` option initialization.
+
 0.8.1 - 2019-02-04
 ------------------
 

--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     from flake8.util import ast, iter_child_nodes
 
-__version__ = '0.8.1'
+__version__ = '0.8.2'
 
 PYTHON_VERSION = sys.version_info[:3]
 PY2 = PYTHON_VERSION[0] == 2
@@ -83,6 +83,15 @@ class _FunctionType(object):
     METHOD = 'method'
 
 
+_default_ignore_names = [
+        'setUp',
+        'tearDown',
+        'setUpClass',
+        'tearDownClass',
+        'setUpTestData',
+        'failureException',
+        'longMessage',
+        'maxDiff']
 _default_classmethod_decorators = ['classmethod']
 _default_staticmethod_decorators = ['staticmethod']
 
@@ -102,15 +111,7 @@ class NamingChecker(object):
     version = __version__
     decorator_to_type = _build_decorator_to_type(
         _default_classmethod_decorators, _default_staticmethod_decorators)
-    ignore_names = [
-        'setUp',
-        'tearDown',
-        'setUpClass',
-        'tearDownClass',
-        'setUpTestData',
-        'failureException',
-        'longMessage',
-        'maxDiff']
+    ignore_names = frozenset(_default_ignore_names)
 
     def __init__(self, tree, filename):
         self.visitors = BaseASTCheck._checks
@@ -120,7 +121,7 @@ class NamingChecker(object):
     @classmethod
     def add_options(cls, parser):
         options.register(parser, '--ignore-names',
-                         default=cls.ignore_names,
+                         default=_default_ignore_names,
                          action='store',
                          type='string',
                          parse_from_config=True,

--- a/testsuite/N801.py
+++ b/testsuite/N801.py
@@ -1,6 +1,9 @@
 #: N801
 class notok(object):
     pass
+#: Okay(--ignore-names=notok)
+class notok(object):
+    pass
 #: N801
 class Good(object):
     class notok(object):

--- a/testsuite/N802.py
+++ b/testsuite/N802.py
@@ -19,6 +19,9 @@ def _go_od_():
 #: N802:1:5
 def NotOK():
     pass
+#: Okay(--ignore-names=NotOK)
+def NotOK():
+    pass
 #: Okay
 def _():
     pass
@@ -35,6 +38,10 @@ class ClassName(object):
     def __method__(self):
         pass
 #: N802
+class ClassName(object):
+    def notOk(self):
+        pass
+#: Okay(--ignore-names=notOk)
 class ClassName(object):
     def notOk(self):
         pass

--- a/testsuite/N806.py
+++ b/testsuite/N806.py
@@ -22,6 +22,9 @@ def test():
         class Foo(object):
             def test3(self):
                 Bad = 3
+#: Okay(--ignore-names=Bad)
+def test():
+    Bad = 1
 #: Okay
 def good():
     global Bad

--- a/testsuite/N807.py
+++ b/testsuite/N807.py
@@ -35,6 +35,9 @@ class ClassName(object):
     def method(self):
         def __bad():
             pass
+#: Okay(--ignore-names=__bad)
+def __bad():
+    pass
 #: Okay
 def __dir__():
     pass

--- a/testsuite/N815.py
+++ b/testsuite/N815.py
@@ -19,3 +19,6 @@ class C:
 #: N815
 class C:
     mixed_Case = 0
+#: Okay(--ignore-names=mixed_Case)
+class C:
+    mixed_Case = 0

--- a/testsuite/N816.py
+++ b/testsuite/N816.py
@@ -18,3 +18,5 @@ __C6__ = 0
 C6 = 0
 #: Okay
 C_6 = 0.
+#: Okay(--ignore-names=mixedCase)
+mixedCase = 0


### PR DESCRIPTION
cls.ignore_names starts life as a list, which is used as the default
value for the ignore-names option, and then it becomes a frozenset()
once the option is set.

Unfortunately, when flake8's --config option is used, it appears we run
those this sequence more than once, and that results in the frozenset()
being passed as the option's default value, which breaks flake8.

This change moves the default ignore-names list to a module-level
constant alongside the other default lists. This avoids the problem
described above and has the nice side-effect of making the code more
consistent.