### PR TITLE
Handle exception assignment to attribute (py2)

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -473,6 +473,10 @@ def _extract_names(assignment_target):
             if isinstance(assignment_target.name, ast.Tuple):
                 for name in assignment_target.name.elts:
                     yield name.id
+            elif isinstance(assignment_target.name, ast.Attribute):
+                # Python 2 also supports assigning an exception to an attribute
+                # eg. except Exception as obj.attr
+                yield assignment_target.name.attr
             else:
                 yield assignment_target.name.id
         else:

--- a/testsuite/N806_py2.py
+++ b/testsuite/N806_py2.py
@@ -5,9 +5,27 @@ def f():
         f()
     except (A, B) as (a, b):
         pass
+#: Okay
+def f():
+    try:
+        f()
+    except X, foo:
+        pass
 #: N806
 def f():
     try:
         f()
     except (A, B) as (good, BAD):
+        pass
+#: Okay
+def f():
+    try:
+        f()
+    except X, foo.bar:
+        pass
+#: N806
+def f():
+    try:
+        f()
+    except mod.Timeout, mod.ConnectionError:
         pass


### PR DESCRIPTION
Fix for a crash in a little-used piece of Python 2 syntax.

Apparently you can assign to an attribute in a Python 2 exception handler:

```python
except Exception as foo.bar:
```

or (same AST)

```python
except Exception, foo.bar:
```

Unfortunately pep8-naming doesn't handle this, and crashes with 

```pytb
...
  File "/home/mauve/dev/pep8-naming/.tox/py27/local/lib/python2.7/site-packages/pep8ext_naming.py", line 425, in visit_excepthandler
    for error in self._find_errors(node, parents, ignore):
  File "/home/mauve/dev/pep8-naming/.tox/py27/local/lib/python2.7/site-packages/pep8ext_naming.py", line 385, in _find_errors
    for name in _extract_names(assignment_target):
  File "/home/mauve/dev/pep8-naming/.tox/py27/local/lib/python2.7/site-packages/pep8ext_naming.py", line 477, in _extract_names
    yield assignment_target.name.id
AttributeError: 'Attribute' object has no attribute 'id'
```

(It is a SyntaxError in Python 3.)