### PR TITLE
Remove Python 3.3/3.4 (EOL), add 3.8 (alpha)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - env: TOXENV=py38
       dist: xenial
       sudo: required
-      python: 3.8
+      python: 3.8-dev
     - env: TOXENV=pypy
       python: pypy
     - env: TOXENV=py27-flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
   include:
     - env: TOXENV=py27
       python: 2.7
-    - env: TOXENV=py34
-      python: 3.4
     - env: TOXENV=py35
       python: 3.5
     - env: TOXENV=py36
@@ -21,6 +19,10 @@ matrix:
       dist: xenial
       sudo: required
       python: 3.7
+    - env: TOXENV=py38
+      dist: xenial
+      sudo: required
+      python: 3.8
     - env: TOXENV=pypy
       python: pypy
     - env: TOXENV=py27-flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36,py37,pypy,pypy3
+envlist = py27,py35,py36,py37,py38,pypy,pypy3
 
 [testenv]
 commands = python run_tests.py


### PR DESCRIPTION
Python 3.3 and 3.4 are EOL ([3.4 as of March 2019](https://www.python.org/dev/peps/pep-0429/)), so I propose to drop support for these in Travis and Tox.

Meanwhile 3.8 is in alpha for an October release, so add this to start testing against it now.