### PR TITLE
Recognize abc.ABCMeta as a metaclass base type

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -17,6 +17,8 @@ __version__ = '0.9.0.dev0'
 PYTHON_VERSION = sys.version_info[:3]
 PY2 = PYTHON_VERSION[0] == 2
 
+METACLASS_BASES = frozenset(('type', 'ABCMeta'))
+
 # Node types which may contain class methods
 METHOD_CONTAINER_NODES = {ast.If, ast.While, ast.For, ast.With}
 FUNC_NODES = (ast.FunctionDef,)
@@ -204,7 +206,8 @@ class NamingChecker(object):
         cls_bases = [b for b in cls_node.bases if isinstance(b, ast.Name)]
         # If this class inherits from `type`, it's a metaclass, and we'll
         # consider all of it's methods to be classmethods.
-        ismetaclass = any(name for name in cls_bases if name.id == 'type')
+        ismetaclass = any(
+            name for name in cls_bases if name.id in METACLASS_BASES)
         self.set_function_nodes_types(
             iter_child_nodes(cls_node), ismetaclass, late_decoration)
 

--- a/testsuite/N804.py
+++ b/testsuite/N804.py
@@ -1,3 +1,5 @@
+from abc import ABCMeta
+
 #: N804:7:13
 class Foo(object):
     @classmethod
@@ -25,6 +27,9 @@ class Meta(type):
         pass
 #: Okay
 class MetaMethod(type):
+    def test(cls):
+        pass
+class MetaMethod(ABCMeta):
     def test(cls):
         pass
 #: Okay

--- a/testsuite/N805.py
+++ b/testsuite/N805.py
@@ -1,3 +1,5 @@
+from abc import ABCMeta
+
 #: Okay
 class C:
     def __init__(*args, **kwargs):
@@ -42,6 +44,12 @@ class Foo(object):
         pass
 #: Okay
 class Meta(type):
+    def __new__(cls, name, bases, attrs):
+        pass
+    def test(cls):
+        pass
+#: Okay
+class Meta(ABCMeta):
     def __new__(cls, name, bases, attrs):
         pass
     def test(cls):


### PR DESCRIPTION
This is a common metaclass base type because it comes from the standard
library. Extend our metaclass detection heuristic (#47) to recognize it.