### PR TITLE
Don't offset lineno when reporting errors for Python >= 3.8

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -65,10 +65,12 @@ class _ASTCheckMeta(type):
 def _err(self, node, code, **kwargs):
     lineno, col_offset = node.lineno, node.col_offset
     if isinstance(node, ast.ClassDef):
-        lineno += len(node.decorator_list)
+        if PYTHON_VERSION < (3, 8):
+            lineno += len(node.decorator_list)
         col_offset += 6
     elif isinstance(node, FUNC_NODES):
-        lineno += len(node.decorator_list)
+        if PYTHON_VERSION < (3, 8):
+            lineno += len(node.decorator_list)
         col_offset += 4
     code_str = getattr(self, code)
     if kwargs:

--- a/testsuite/N80x.py
+++ b/testsuite/N80x.py
@@ -1,0 +1,8 @@
+#: N802:2:5
+@foo
+def fn_with_decorator_Error():
+    pass
+#: N801:2:7
+@foo
+class class_with_decorator_Error:
+    pass


### PR DESCRIPTION
In Python 3.8, bpo-33211 addressed what is considered a bug where a
function or a class with a decorator would report an incorrect `lineno`
and `col_offset`.  In versions < 3.8, the first decorator line was
reported, which requires the accounted for offset.  Now, the actual
`lineno` and `col_offset` is reported by the `ast` module.

Please see https://bugs.python.org/issue33211 for reference.