### PR TITLE
Apply --ignore-names to N804 and N805

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ The following flake8 options are added:
 
 --ignore-names              Ignore errors for specific variable names.
 
-                            Currently, this option can only be used for N802, N803, N806, N815, and N816 errors.
+                            Currently, this option can only be used for N802, N803, N804, N805, N806, N815, and N816 errors.
 
                             Default: ``setUp,tearDown,setUpClass,tearDownClass,setUpTestData,failureException,longMessage,maxDiff``.
 

--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -330,10 +330,10 @@ class FunctionArgNamesCheck(BaseASTCheck):
         function_type = getattr(node, 'function_type', _FunctionType.FUNCTION)
 
         if function_type == _FunctionType.METHOD:
-            if name0 != 'self':
+            if name0 != 'self' and name0 not in ignore:
                 yield self.err(arg0, 'N805')
         elif function_type == _FunctionType.CLASSMETHOD:
-            if name0 != 'cls':
+            if name0 != 'cls' and name0 not in ignore:
                 yield self.err(arg0, 'N804')
         for arg, name in arg_name_tuples:
             if name.lower() != name and name not in ignore:

--- a/testsuite/N804.py
+++ b/testsuite/N804.py
@@ -16,6 +16,11 @@ class Foo(object):
 
     def __init_subclass(self, ads):
         pass
+#: Okay(--ignore-names=klass)
+class SpecialConventionCase(object):
+    @classmethod
+    def prepare_meta(klass, root):
+        pass
 #: N804:3:14(--classmethod-decorators=clazzy,cool)
 class NewClassIsRequired(object):
     @cool

--- a/testsuite/N805.py
+++ b/testsuite/N805.py
@@ -17,6 +17,10 @@ class Foo(object):
 
     def bad(ads, self):
         pass
+#: Okay(--ignore-names=source)
+class GraphQLNode(object):
+    def resolve_foo(source, info):
+        pass
 #: Okay
 class Foo(object):
     def __new__(cls):


### PR DESCRIPTION
This would be helpful when using libraries / DSLs that have their own conventions around method args.