### PR TITLE
Build using Python 3.8 instead of 3.8-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - env: TOXENV=py38
       dist: xenial
       sudo: required
-      python: 3.8-dev
+      python: 3.8
     - env: TOXENV=pypy
       python: pypy
     - env: TOXENV=py27-flake8


### PR DESCRIPTION
Python 3.8 has been officially released for quite some time now.