### PR TITLE
Improve known metaclass base class detection

### DIFF
--- a/testsuite/N805.py
+++ b/testsuite/N805.py
@@ -1,3 +1,4 @@
+import abc
 from abc import ABCMeta
 
 #: Okay
@@ -58,6 +59,12 @@ class Meta(type):
         pass
 #: Okay
 class Meta(ABCMeta):
+    def __new__(cls, name, bases, attrs):
+        pass
+    def test(cls):
+        pass
+#: Okay
+class Meta(abc.ABCMeta):
     def __new__(cls, name, bases, attrs):
         pass
     def test(cls):


### PR DESCRIPTION
We previously only looked for known metaclass base classes that were
inheriting using the simple `ast.Name` syntax:

    class Meta(type): pass
    class Meta(ABCMeta): pass

We weren't accounting for the `ast.Attribute` syntax:

    class Meta(abc.ABCMeta): pass

This second syntax will now also match `ABCMeta` and be recognized as a
metaclass base class.

We could alternatively add `abc.ABCMeta` to METACLASS_BASES and
construct the fully-qualified name of each base class that uses the
`ast.Attribute` syntax. The simpler approach used here is currently
unambiguous, so we'll start with it.

Fixes #136