### PR TITLE
check annotated variable declarations

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -436,6 +436,8 @@ class VariablesCheck(BaseASTCheck):
         for error in self._find_errors(node.target, parents, ignore):
             yield error
 
+    visit_annassign = visit_namedexpr
+
     def visit_with(self, node, parents, ignore):
         if PY2:
             for error in self._find_errors(

--- a/testsuite/N8xx_py36.py
+++ b/testsuite/N8xx_py36.py
@@ -1,0 +1,16 @@
+# python_version >= '3.6'
+#: Okay
+var1: int = 1
+var2: int
+def some():
+    variable: int = 1
+class Test(object):
+    variable: int = 1
+#: N816:1:1
+mixedCase: int = 1
+#: N806:2:5
+def some():
+    mixedCase: int = 1
+#: N815:2:5
+class Test(object):
+    mixedCase: int = 1


### PR DESCRIPTION
PEP 526, syntax for variable annotations, has been introduced in
Python 3.6.

https://www.python.org/dev/peps/pep-0526/

fixes #138