### PR TITLE
Recognize __class_getitem__ as a class method

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -19,6 +19,11 @@ __version__ = '0.10.0'
 PYTHON_VERSION = sys.version_info[:3]
 PY2 = PYTHON_VERSION[0] == 2
 
+CLASS_METHODS = frozenset((
+    '__new__',
+    '__init_subclass__',
+    '__class_getitem__',
+))
 METACLASS_BASES = frozenset(('type', 'ABCMeta'))
 
 # Node types which may contain class methods
@@ -234,7 +239,7 @@ class NamingChecker(object):
             if not isinstance(node, FUNC_NODES):
                 continue
             node.function_type = _FunctionType.METHOD
-            if node.name in ('__new__', '__init_subclass__') or ismetaclass:
+            if node.name in CLASS_METHODS or ismetaclass:
                 node.function_type = _FunctionType.CLASSMETHOD
             if node.name in late_decoration:
                 node.function_type = late_decoration[node.name]

--- a/testsuite/N805.py
+++ b/testsuite/N805.py
@@ -49,7 +49,15 @@ class Foo(object):
     test2 = staticmethod(test2)
 #: Okay
 class Foo(object):
+    def __new__(cls):
+        pass
+#: Okay
+class Foo(object):
     def __init_subclass__(cls):
+        pass
+#: Okay
+class Foo(object):
+    def __class_getitem__(cls, key):
         pass
 #: Okay
 class Meta(type):


### PR DESCRIPTION
According to PEP 560:

> The __class_getitem__ is automatically a class method and does not
> require @classmethod decorator (similar to __init_subclass__) and is
> inherited like normal attributes.

Classify this name the same way we do `__new__` and `__init_subclass__`.

Fixes #144