### PR TITLE
Fix an AttributeError when processing decorators

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+0.11.1 - 2020-06-16
+-------------------
+
+* Fix an AST-related AttributeError when processing decorator lists.
+
+
 0.11.0 - 2020-06-16
 -------------------
 

--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     from flake8.util import ast, iter_child_nodes
 
-__version__ = '0.11.0'
+__version__ = '0.11.1'
 
 PYTHON_VERSION = sys.version_info[:3]
 PY2 = PYTHON_VERSION[0] == 2
@@ -256,10 +256,19 @@ class NamingChecker(object):
                 node.function_type = late_decoration[node.name]
             elif node.decorator_list:
                 for d in node.decorator_list:
-                    name = d.func.id if isinstance(d, ast.Call) else d.id
+                    name = self.find_decorator_name(d)
                     if name in self.decorator_to_type:
                         node.function_type = self.decorator_to_type[name]
                         break
+
+    @classmethod
+    def find_decorator_name(cls, d):
+        if isinstance(d, ast.Name):
+            return d.id
+        elif isinstance(d, ast.Attribute):
+            return d.attr
+        elif isinstance(d, ast.Call):
+            return cls.find_decorator_name(d.func)
 
     @staticmethod
     def find_global_defs(func_def_node):

--- a/testsuite/N805.py
+++ b/testsuite/N805.py
@@ -109,6 +109,29 @@ class C(object):
     @myclassmethod('foo')
     def bar(cls):
         return 42
+#: Okay
+class PropertySetter(object):
+    @property
+    def var(self):
+        return True
+    @var.setter
+    def var(self, value):
+        self.var = value
+#: Okay
+class CalledInstanceDecorator(object):
+    @module.inner.decorator()
+    def test(self):
+        pass
+#: Okay(--classmethod-decorators=decorator)
+class CalledClassDecorator(object):
+    @module.inner.decorator()
+    def test(cls):
+        pass
+#: Okay(--staticmethod-decorators=decorator)
+class CalledStaticDecorator(object):
+    @module.inner.decorator()
+    def test():
+        pass
 #: Okay(--staticmethod-decorators=ecstatik,stcmthd)
 class NewStaticMethodDecorators(object):
     @ecstatik


### PR DESCRIPTION
I had assumed that each node in the decorator list was either a Call or
a Name, but it can also be an Attribute when the decorator uses module
notation (e.g. `@module.decorator()`).

Fixed #152 