### PR TITLE
Django `classproperty`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ The following flake8 options are added:
 
                             Used to prevent false N804 errors.
 
-                            Default: ``classmethod``.
+                            Default: ``classmethod,classproperty``.
 
 --staticmethod-decorators   List of method decorators pep8-naming plugin should consider static method.
 

--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -111,7 +111,7 @@ _default_ignore_names = [
         'failureException',
         'longMessage',
         'maxDiff']
-_default_classmethod_decorators = ['classmethod']
+_default_classmethod_decorators = ['classmethod', 'classproperty']
 _default_staticmethod_decorators = ['staticmethod']
 
 


### PR DESCRIPTION
Hello. Just wondering if [Django's `classproperty` decorator](https://docs.djangoproject.com/en/3.0/_modules/django/utils/decorators/) is common enough to add to the list of default `classmethod` decorators. I imagine that this may also be a reasonably common name for this functionality implemented by other codebase and/or frameworks too.

If not, feel free to close the PR. Thanks!