### PR TITLE
Exempt asyncSetUp and asyncTearDown, just like setUp and tearDown

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ The following flake8 options are added:
 
                             Currently, this option can only be used for N802, N803, N804, N805, N806, N815, and N816 errors.
 
-                            Default: ``setUp,tearDown,setUpClass,tearDownClass,setUpTestData,failureException,longMessage,maxDiff``.
+                            Default: ``setUp,tearDown,setUpClass,tearDownClass,asyncSetUp,asyncTearDown,setUpTestData,failureException,longMessage,maxDiff``.
 
 --classmethod-decorators    List of method decorators pep8-naming plugin should consider class method.
 

--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -107,6 +107,8 @@ _default_ignore_names = [
         'tearDown',
         'setUpClass',
         'tearDownClass',
+        'asyncSetUp',
+        'asyncTearDown',
         'setUpTestData',
         'failureException',
         'longMessage',

--- a/testsuite/N802.py
+++ b/testsuite/N802.py
@@ -70,5 +70,9 @@ class TestCase:
         pass
     def tearDownClass(self):
         pass
+    def asyncSetUp(self):
+        pass
+    def asyncTearDown(self):
+        pass
     def setUpTestData(self):
         pass


### PR DESCRIPTION
These are new in Python 3.8's unittest.IsolatedAsyncioTestCase.