### PR TITLE
Avoid stack exhaustion in superclass_names()

### DIFF
--- a/testsuite/N818.py
+++ b/testsuite/N818.py
@@ -28,3 +28,7 @@ class Mixin:
     pass
 class MixinActionClass(Mixin, MixinError):
     pass
+#: Okay
+from decimal import Decimal
+class Decimal(Decimal):
+    pass


### PR DESCRIPTION
Because this function is recursive, it can exhaust the stack if the
class hierarchy contains duplicate names. Avoid that using simple
memoization.

Also, these two supporting functions can be classmethods because they
don't use any instance-level state.

Fixes #174