### PR TITLE
fix: update flake8 output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ When both ``flake8`` and ``pep8-naming`` are installed, the plugin is
 available in ``flake8``::
 
   $ flake8 --version
-  2.0 (pep8: 1.4.3, pyflakes: 0.6.1, naming: 0.2)
+  4.0.1 (mccabe: 0.6.1, naming: 0.12.1, pycodestyle: 2.8.0, pyflakes: 2.4.0) CPython 3.8.10 on Linux
 
 By default the plugin is enabled.
 


### PR DESCRIPTION
The pep8 entry was quite confusing to me and I don't think it will ever show up with a newish flake8 version. Also update naming to the latest release.