### PR TITLE
setup.py: Drop flake8-polyfill dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     license='Expat license',
     package_dir={'': 'src'},
     py_modules=['pep8ext_naming'],
-    install_requires=['flake8>=3.9.1', 'flake8_polyfill>=1.0.2,<2'],
+    install_requires=['flake8>=3.9.1'],
     zip_safe=False,
     entry_points={
         'flake8.extension': [


### PR DESCRIPTION
Newer versions (> 3.x) of flake8 no longer require flake8-polyfill

Fixes #185 
Also refer https://github.com/PyCQA/flake8-polyfill/pull/14