### PR TITLE
N815: Ignore TypedDict class variable casing

### DIFF
--- a/testsuite/N815_py38.py
+++ b/testsuite/N815_py38.py
@@ -1,0 +1,12 @@
+# python_version >= '3.8'
+#: Okay
+class MyDict(TypedDict):
+    mixedCase: str
+class MyOtherDict(MyDict):
+    more_Mixed_Case: str
+#: N815
+class TypedDict:
+    mixedCase: str
+#: N815
+class TypedDict:
+    more_Mixed_Case: str


### PR DESCRIPTION
Prosed fix for #178 

Add specific exemption from N815 for all subclasses of `TypedDict` because class variable naming conventions should not apply to dictionary keys.

I've tried to reuse code from the rule for `Exceptions` (N818) as per the suggestion on #178.

This is my first time working with the `ast` module or with any `flake8` plugin so please bear that in mind when reviewing this PR. Any advice on whether it's reasonable to tag every `ClassDef` with the names of its superclasses, and potential performance concerns around that, would be very welcome. On balance, I thought it may be preferable to do this rather than determining the superclasses again for every variable in a class.

Thanks :)