### PR TITLE
Remove Python 3.5 and 3.6 from the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", pypy-2.7, pypy-3.7]
+        python-version: [2.7, 3.7, 3.8, 3.9, "3.10", pypy-2.7, pypy-3.7]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Both of these versions are beyond their official end-of-life.