### PR TITLE
Remove flake8-polyfill

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,9 +1,9 @@
-import optparse
 import os
 import platform
 import re
 import sys
 
+from flake8.options.manager import OptionManager
 import pep8ext_naming
 
 
@@ -69,20 +69,9 @@ def load_tests(lines):
         yield testcase, code, options
 
 
-class OptionsManager(optparse.OptionParser):
-    """A Flake8-2.x-compatible OptionsManager."""
-    def __init__(self, *args, **kwargs):
-        optparse.OptionParser.__init__(self, *args, **kwargs)
-        self.config_options = []
-        self.ignore = []
-
-    def extend_default_ignore(self, new_ignores):
-        self.ignore += new_ignores
-
-
 def parse_options(checker, options):
     """Parse the CLI-style flags from `options` and expose to `checker`"""
-    options_manager = OptionsManager('flake8')
+    options_manager = OptionManager('flake8', version=pep8ext_naming.__version__)
     options_manager.add_option('--select', default=[])
     options_manager.add_option('--extended-default-select', default=['N'])
     options_manager.add_option('--extend-select', default=[])

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     license='Expat license',
     package_dir={'': 'src'},
     py_modules=['pep8ext_naming'],
-    install_requires=['flake8>=3.9.1', 'flake8_polyfill>=1.0.2,<2'],
+    install_requires=['flake8>=3.9.1'],
     zip_safe=False,
     entry_points={
         'flake8.extension': [

--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -6,7 +6,6 @@ from functools import partial
 from itertools import chain
 
 from flake8 import style_guide
-from flake8_polyfill import options
 
 try:
     import ast
@@ -128,34 +127,32 @@ class NamingChecker:
 
     @classmethod
     def add_options(cls, parser):
-        options.register(parser, '--ignore-names',
-                         default=_default_ignore_names,
-                         action='store',
-                         type='string',
-                         parse_from_config=True,
-                         comma_separated_list=True,
-                         help='List of names or glob patterns the pep8-naming '
-                              'plugin should ignore. (Defaults to %default)')
-
-        options.register(parser, '--classmethod-decorators',
-                         default=_default_classmethod_decorators,
-                         action='store',
-                         type='string',
-                         parse_from_config=True,
-                         comma_separated_list=True,
-                         help='List of method decorators pep8-naming plugin '
-                              'should consider classmethods (Defaults to '
-                              '%default)')
-
-        options.register(parser, '--staticmethod-decorators',
-                         default=_default_staticmethod_decorators,
-                         action='store',
-                         type='string',
-                         parse_from_config=True,
-                         comma_separated_list=True,
-                         help='List of method decorators pep8-naming plugin '
-                              'should consider staticmethods (Defaults to '
-                              '%default)')
+        parser.add_option(
+            '--ignore-names',
+            default=_default_ignore_names,
+            parse_from_config=True,
+            comma_separated_list=True,
+            help='List of names or glob patterns the pep8-naming '
+            'plugin should ignore. (Defaults to %default)',
+        )
+        parser.add_option(
+            '--classmethod-decorators',
+            default=_default_classmethod_decorators,
+            parse_from_config=True,
+            comma_separated_list=True,
+            help='List of method decorators pep8-naming plugin '
+            'should consider classmethods (Defaults to '
+            '%default)',
+        )
+        parser.add_option(
+            '--staticmethod-decorators',
+            default=_default_staticmethod_decorators,
+            parse_from_config=True,
+            comma_separated_list=True,
+            help='List of method decorators pep8-naming plugin '
+            'should consider staticmethods (Defaults to '
+            '%default)',
+        )
         parser.extend_default_ignore(['N818'])
 
     @classmethod


### PR DESCRIPTION
This library was used to maintain compatibility with flake8 2.x, but
it's no longer needed now that we depend on flake8 3.9+.