### PR TITLE
Add N819 specifically for package or module imports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ These error codes are emitted:
 +---------+-----------------------------------------------------------------+
 | _`N811` | constant imported as non constant (`constants`_)                |
 +---------+-----------------------------------------------------------------+
-| _`N812` | lowercase imported as non-lowercase                             |
+| _`N812` | lowercase imported as non lowercase                             |
 +---------+-----------------------------------------------------------------+
 | _`N813` | camelcase imported as lowercase                                 |
 +---------+-----------------------------------------------------------------+
@@ -73,6 +73,9 @@ These error codes are emitted:
 +---------+-----------------------------------------------------------------+
 | _`N818` | error suffix in exception names (`exceptions`_)                 |
 +---------+-----------------------------------------------------------------+
+| _`N819` | package or module imported as non lowercase                     |
+|         | (`package and module names`_)                                   |
++---------+-----------------------------------------------------------------+
 
 .. _class names: https://www.python.org/dev/peps/pep-0008/#class-names
 .. _constants: https://www.python.org/dev/peps/pep-0008/#constants
@@ -80,7 +83,7 @@ These error codes are emitted:
 .. _function names: https://www.python.org/dev/peps/pep-0008/#function-and-variable-names
 .. _function arguments: https://www.python.org/dev/peps/pep-0008/#function-and-method-arguments
 .. _method names: https://www.python.org/dev/peps/pep-0008/#method-names-and-instance-variables
-
+.. _package and module names: https://peps.python.org/pep-0008/#package-and-module-names
 Options
 -------
 

--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -390,6 +390,7 @@ class ImportAsCheck(BaseASTCheck):
     N813 = "camelcase '{name}' imported as lowercase '{asname}'"
     N814 = "camelcase '{name}' imported as constant '{asname}'"
     N817 = "camelcase '{name}' imported as acronym '{asname}'"
+    N819 = "package or module '{name}' imported as non lowercase '{asname}'"
 
     def visit_importfrom(self, node, parents, ignore=None):
         for name in node.names:
@@ -412,7 +413,13 @@ class ImportAsCheck(BaseASTCheck):
                 else:
                     yield self.err(node, 'N814', **err_kwargs)
 
-    visit_import = visit_importfrom
+    def visit_import(self, node, parents, ignore=None):
+        for name in node.names:
+            asname = name.asname
+            if not asname:
+                continue
+            if asname.lower() != asname:
+                yield self.err(node, 'N819', name=name.name, asname=asname)
 
 
 class VariablesCheck(BaseASTCheck):

--- a/testsuite/N819.py
+++ b/testsuite/N819.py
@@ -1,0 +1,18 @@
+#: N819:1:1
+import os as OS
+#: Okay
+import os as myos
+#: Okay
+import good as good
+#: Okay
+import GOOD as good
+#: N819:1:1
+import good as BAD
+#: N819:1:1
+import good as Bad
+#: Okay
+import underscore as _
+#: Okay
+import good as γ
+#: N819:1:1
+import GOOD as Γ

--- a/testsuite/N81x.py
+++ b/testsuite/N81x.py
@@ -1,15 +1,11 @@
-#: N812:1:1
-import os as OS
 #: Okay
-import os as myos
-#: Okay
-import good as good
-#: Okay
-import underscore as _
+from mod import underscore as _
 #: Okay
 from mod import good as nice, NICE as GOOD, Camel as Memel
 #: N811:1:1
 from mod import GOOD as bad
+#: N812:1:1
+from mod import good as BAD
 #: N812:1:1
 from mod import good as Bad
 #: N813:1:1
@@ -19,11 +15,7 @@ from mod import CamelCase as CONSTANT
 #: N817:1:1
 from mod import CamelCase as CC
 #: Okay
-import good as γ
-#: Okay
 from mod import good as γ
-#: Okay
-import GOOD as Γ
 #: Okay
 from mod import GOOD as Γ
 #: Okay


### PR DESCRIPTION
These are differences in behavior based on existing and new test cases:

statement | before | now
-- | -- | --
import os as OS | N812 lowercase 'os' imported as non lowercase 'OS' | N819 package or module 'os' imported as non lowercase 'OS'
import GOOD as good | N811 constant 'GOOD' imported as non constant 'good' | Okay (because GOOD is a package or module)
import good as BAD | N812 lowercase 'good' imported as non lowercase 'BAD' | N819 package or module 'good' imported as non lowercase 'BAD'
import good as Bad | N812 lowercase 'good' imported as non lowercase 'Bad' | N819 package or module 'good' imported as non lowercase 'Bad'
import GOOD as Γ | Okay | N819 package or module 'GOOD' imported as non lowercase 'Γ'

Hope it makes sense based on the discussion in #201.