### PR TITLE
Ignore methods decorated by @typing.override

### DIFF
--- a/testsuite/N802.py
+++ b/testsuite/N802.py
@@ -53,6 +53,14 @@ class ClassName:
     def notOk(self):
         pass
 #: Okay
+class ClassName:
+    @override
+    def notOk(self):
+        pass
+    @typing.override
+    def alsoNotOk(self):
+        pass
+#: Okay
 def setUp():
     pass
 


### PR DESCRIPTION
PEP 698 introduces the `@typing.override` decorator which indicates a method overrides a base class method. It's nice to skip naming checks in this case because the user don't have any control over the name used by the subclass.

Fixes #215