### PR TITLE
Fix Issue 218: ignore-names globbing is not case-sensitive on Windows

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -3,7 +3,7 @@ import ast
 import sys
 from ast import iter_child_nodes
 from collections import deque
-from fnmatch import fnmatch
+from fnmatch import fnmatchcase
 from functools import partial
 from itertools import chain
 
@@ -68,7 +68,7 @@ def _err(self, node, code, **kwargs):
 
 
 def _ignored(name, ignore):
-    return any(fnmatch(name, i) for i in ignore)
+    return any(fnmatchcase(name, i) for i in ignore)
 
 
 BaseASTCheck = _ASTCheckMeta('BaseASTCheck', (object,),

--- a/testsuite/N801.py
+++ b/testsuite/N801.py
@@ -7,6 +7,9 @@ class notok:
 #: Okay(--ignore-names=*ok)
 class notok:
     pass
+#: N801:1:7(--ignore-names=*OK)
+class notok:
+    pass
 #: N801
 class Good:
     class notok:

--- a/testsuite/N802.py
+++ b/testsuite/N802.py
@@ -25,6 +25,9 @@ def NotOK():
 #: Okay(--ignore-names=*OK)
 def NotOK():
     pass
+#: N802:1:5(--ignore-names=*ok)
+def NotOK():
+    pass
 #: Okay
 def _():
     pass

--- a/testsuite/N803.py
+++ b/testsuite/N803.py
@@ -40,6 +40,9 @@ def b13(BAD, *VERYBAD, **EXTRABAD):
 #: Okay(--ignore-names=*BAD)
 def b13(BAD, *VERYBAD, **EXTRABAD):
     pass
+#: N803:1:9(--ignore-names=*bad)
+def b13(BAD):
+    pass
 #: N803:1:9
 def b14(BAD):
     pass

--- a/testsuite/N804.py
+++ b/testsuite/N804.py
@@ -21,6 +21,11 @@ class SpecialConventionCase:
     @classmethod
     def prepare_meta(klass, root):
         pass
+#: N804(--ignore-names=KLASS)
+class SpecialConventionCase:
+    @classmethod
+    def prepare_meta(klass, root):
+        pass
 #: Okay(--ignore-names=_*)
 class SpecialConventionCase:
     @classmethod

--- a/testsuite/N805.py
+++ b/testsuite/N805.py
@@ -26,6 +26,10 @@ class Foo:
 class GraphQLNode:
     def resolve_foo(source, info):
         pass
+#: N805(--ignore-names=SOURCE)
+class GraphQLNode:
+    def resolve_foo(source, info):
+        pass
 #: Okay
 class Foo:
     def __new__(cls):

--- a/testsuite/N806.py
+++ b/testsuite/N806.py
@@ -31,6 +31,9 @@ def test():
 #: Okay(--ignore-names=B*)
 def test():
     Bad = 1
+#: N806(--ignore-names=b*)
+def test():
+    Bad = 1
 #: Okay
 def good():
     global Bad

--- a/testsuite/N807.py
+++ b/testsuite/N807.py
@@ -46,11 +46,11 @@ class ClassName:
     def method(self):
         def __bad__():
             pass
-#: Okay(--ignore-names=__bad)
-def __bad():
+#: Okay(--ignore-names=__bad__)
+def __bad__():
     pass
 #: Okay(--ignore-names=__*)
-def __bad():
+def __bad__():
     pass
 #: Okay
 def __dir__():

--- a/testsuite/N807.py
+++ b/testsuite/N807.py
@@ -52,6 +52,9 @@ def __bad__():
 #: Okay(--ignore-names=__*)
 def __bad__():
     pass
+#: N807(--ignore-names=__B*)
+def __bad__():
+    pass
 #: Okay
 def __dir__():
     pass

--- a/testsuite/N815.py
+++ b/testsuite/N815.py
@@ -25,3 +25,6 @@ class C:
 #: Okay(--ignore-names=*Case)
 class C:
     mixed_Case = 0
+#: N815(--ignore-names=*case)
+class C:
+    mixed_Case = 0

--- a/testsuite/N816.py
+++ b/testsuite/N816.py
@@ -22,6 +22,8 @@ C_6 = 0.
 mixedCase = 0
 #: Okay(--ignore-names=*Case)
 mixedCase = 0
+#: N816(--ignore-names=*case)
+mixedCase = 0
 #: Okay
 Γ = 1
 #: N816


### PR DESCRIPTION
I created this branch to fix issue #218. While I was updating the unit tests, I found a couple of tests for N807(--ignore-names) that would have passed regardless of whether that option was included, so this PR also includes a commit that fixes those tests.

The tests that I wrote as part of this fix would only fail on Windows without the fix -- I don't see an easy way to write tests that would fail on all platforms without the fix, but I'm open to suggestions.