### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", pypy-3.7]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", pypy-3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py37-flake85,
     py38-flake8-{v5,v6,latest},
     py39-flake8-{v5,v6,latest},
     py310-flake8-{v5,v6,latest},
@@ -11,13 +10,12 @@ envlist =
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312, py312-flake8
-    pypy-3.7: pypy3
+    pypy-3.8: pypy3
 
 [testenv]
 commands = python run_tests.py


### PR DESCRIPTION
Python 3.7 reached the end of its supported life in June 2023.