### PR TITLE
Add support for type variable name convention check

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,9 @@ These error codes are emitted:
 +---------+-----------------------------------------------------------------+
 | _`N807` | function name should not start and end with '__'                |
 +---------+-----------------------------------------------------------------+
+| _`N808` | type variable names should use CapWords convention and an       |
+|         | optional suffix '_co' or '_contra' (`type variable names`_)     |
++---------+-----------------------------------------------------------------+
 | _`N811` | constant imported as non constant (`constants`_)                |
 +---------+-----------------------------------------------------------------+
 | _`N812` | lowercase imported as non-lowercase                             |
@@ -80,6 +83,7 @@ These error codes are emitted:
 .. _function names: https://www.python.org/dev/peps/pep-0008/#function-and-variable-names
 .. _function arguments: https://www.python.org/dev/peps/pep-0008/#function-and-method-arguments
 .. _method names: https://www.python.org/dev/peps/pep-0008/#method-names-and-instance-variables
+.. _type variable names: https://peps.python.org/pep-0008/#type-variable-names
 
 Options
 -------

--- a/run_tests.py
+++ b/run_tests.py
@@ -24,9 +24,6 @@ def main():
     test_count = 0
     errors = 0
     for filename in os.listdir('testsuite'):
-        if filename != "N808.py":
-            continue
-
         filepath = os.path.join('testsuite', filename)
         with open(filepath, encoding='utf8') as fd:
             lines = list(fd)

--- a/run_tests.py
+++ b/run_tests.py
@@ -24,6 +24,9 @@ def main():
     test_count = 0
     errors = 0
     for filename in os.listdir('testsuite'):
+        if filename != "N808.py":
+            continue
+
         filepath = os.path.join('testsuite', filename)
         with open(filepath, encoding='utf8') as fd:
             lines = list(fd)

--- a/testsuite/N808.py
+++ b/testsuite/N808.py
@@ -1,0 +1,47 @@
+from typing import TypeVar
+
+#: Okay
+Ok = TypeVar("Ok")
+
+#: N808
+notok = TypeVar("notok")
+
+#: N808
+notok_co = TypeVar("notok_co")
+
+#: Okay(--ignore-names=notok)
+notok = TypeVar("notok")
+
+#: N808:1:1(--ignore-names=*OK)
+notok = TypeVar("notok")
+
+#: Okay
+Ok_co = TypeVar("Ok_co", covariant=True)
+
+#: Okay
+Ok_contra = TypeVar("Ok_contra", contravariant=True)
+
+#: N808
+Ok__contra = TypeVar("Ok__contra", contravariant=True)
+
+#: Okay
+Ok_co = TypeVar("Ok_co")
+
+#: Okay
+Ok_contra = TypeVar("Ok_contra")
+
+#: Okay
+Good = TypeVar("Good")
+
+#: N808
+__NotGood = TypeVar("__NotGood")
+
+#: N808
+__NotGood__ = TypeVar("__NotGood__")
+
+#: N808
+NotGood__ = TypeVar("NotGood__")
+
+# Make sure other function calls do not get checked
+#: Okay
+t = str('something')


### PR DESCRIPTION
Proposed implementation for #163.

Adds support for type variable name convention check, as mentioned in [PEP8](https://peps.python.org/pep-0008/#type-variable-names):

> Names of type variables introduced in [PEP 484](https://peps.python.org/pep-0484/) should normally use CapWords preferring short names: T, AnyStr, Num. It is recommended to add suffixes _co or _contra to the variables used to declare covariant or contravariant behavior correspondingly:

Proposed name is N808 due to the relationship with the class name convention.

It's my first time contributing, so please let me know if anything needs to be done differently!
Thank you