### PR TITLE
Use __init_subclass__ for subclass registration

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 from fnmatch import fnmatchcase
 from functools import partial
 from itertools import chain
+from typing import List, Tuple
 
 from flake8 import style_guide
 
@@ -34,8 +35,8 @@ FUNC_NODES = (ast.FunctionDef, ast.AsyncFunctionDef)
 class BaseASTCheck:
     """Base for AST Checks."""
 
-    all: list['BaseASTCheck'] = []
-    codes: tuple[str, ...]
+    all: List['BaseASTCheck'] = []
+    codes: Tuple[str, ...]
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -6,7 +6,6 @@ from collections.abc import Iterable
 from fnmatch import fnmatchcase
 from functools import partial
 from itertools import chain
-from typing import List, Tuple
 
 from flake8 import style_guide
 
@@ -35,8 +34,8 @@ FUNC_NODES = (ast.FunctionDef, ast.AsyncFunctionDef)
 class BaseASTCheck:
     """Base for AST Checks."""
 
-    all: List['BaseASTCheck'] = []
-    codes: Tuple[str, ...]
+    all: list['BaseASTCheck'] = []
+    codes: tuple[str, ...]
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)


### PR DESCRIPTION
Python 3.6 introduced `__init_subclass__(cls)`, which provides a nicer subclass registration pattern than the previous metaclass-based approach.