### PR TITLE
Add a fast path for NameSets without wildcards

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -6,7 +6,6 @@ from collections.abc import Iterable
 from fnmatch import fnmatchcase
 from functools import partial
 from itertools import chain
-from typing import override
 
 from flake8 import style_guide
 
@@ -59,13 +58,11 @@ class NameSet(frozenset[str]):
     """A set of names that can be matched as Unix shell-style wildcards."""
     _fnmatch: bool = False
 
-    @override
     def __new__(cls, iterable: Iterable[str]):
         obj = super().__new__(cls, iterable)
         obj._fnmatch = any(c in r"*?[" for name in iterable for c in name)
         return obj
 
-    @override
     def __contains__(self, item: object, /) -> bool:
         if self._fnmatch and isinstance(item, str):
             return any(fnmatchcase(item, name) for name in self)

--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -60,7 +60,7 @@ class NameSet(frozenset[str]):
 
     def __new__(cls, iterable: Iterable[str]):
         obj = super().__new__(cls, iterable)
-        obj._fnmatch = any(c in r"*?[" for name in iterable for c in name)
+        obj._fnmatch = any("*" in s or "?" in s or "[" in s for s in iterable)
         return obj
 
     def __contains__(self, item: object, /) -> bool:


### PR DESCRIPTION
When the set of ignored names doesn't use shell-style wildcards, we can use the faster `frozenset.__contains__` base implementation rather than the more expensive iteration-based fnmatch'ing approach. This is true for the default ignore list, and I expect its the more common case by far even for those who add their own ignored names.

In a simple local benchmark, this results in a 2x speed improvement for that common (default) path, which I think justifies the small additional complexity.