### PR TITLE
Allow TypeVar names to start with an underscore

### DIFF
--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -537,13 +537,14 @@ class TypeVarNameCheck(BaseASTCheck):
             if func_name != "TypeVar" or name in ignored:
                 continue
 
-            if len(args) == 0 or args[0] != name:
+            if not args or args[0] != name:
                 yield self.err(body, 'N808', name=name)
 
-            if not name[:1].isupper():
+            stripped_name = name.lstrip('_')
+            if not stripped_name[:1].isupper():
                 yield self.err(body, 'N808', name=name)
 
-            parts = name.split('_')
+            parts = stripped_name.split('_')
             if len(parts) > 2:
                 yield self.err(body, 'N808', name=name)
 

--- a/src/pep8ext_naming.py
+++ b/src/pep8ext_naming.py
@@ -540,7 +540,7 @@ class TypeVarNameCheck(BaseASTCheck):
             if not args or args[0] != name:
                 yield self.err(body, 'N808', name=name)
 
-            stripped_name = name.lstrip('_')
+            stripped_name = name.removeprefix('_')
             if not stripped_name[:1].isupper():
                 yield self.err(body, 'N808', name=name)
 

--- a/testsuite/N808.py
+++ b/testsuite/N808.py
@@ -43,7 +43,10 @@ Ok_contra = TypeVar("Ok_contra")
 Good = TypeVar("Good")
 
 #: Okay
-__Good = TypeVar("__Good")
+_Good = TypeVar("_Good")
+
+#: N808
+__NotGood = TypeVar("__NotGood")
 
 #: N808
 __NotGood__ = TypeVar("__NotGood__")

--- a/testsuite/N808.py
+++ b/testsuite/N808.py
@@ -42,8 +42,8 @@ Ok_contra = TypeVar("Ok_contra")
 #: Okay
 Good = TypeVar("Good")
 
-#: N808
-__NotGood = TypeVar("__NotGood")
+#: Okay
+__Good = TypeVar("__Good")
 
 #: N808
 __NotGood__ = TypeVar("__NotGood__")


### PR DESCRIPTION
This is consistent with our CapWords-based N801 class name check, which shares a similar PEP 8 definition.

Resolves #245